### PR TITLE
Restaura dump com base na junção de seus arquivos divididos

### DIFF
--- a/scripts/join_splitted_files.sh
+++ b/scripts/join_splitted_files.sh
@@ -1,0 +1,21 @@
+#!/bin/sh -l
+
+if [[ -z "$1" ]]; then
+    printf "You must pass the import dir as the first argument"
+    exit 1
+fi
+
+DB_RESTORE_DIR=$1
+
+# Join splitted dump files
+for entry in "$DB_RESTORE_DIR"/*
+do
+    dumpFilesDir="$entry/splitted-files/"
+    if [[ ! -d "$dumpFilesDir" ]]; then
+        continue
+    fi
+    echo "Directory found:" "$entry"
+    dumpFile="$entry/dump.tar.gz"
+    echo "Dump file to be created:" "$dumpFile"
+    ls "$dumpFilesDir"* | xargs cat > "$dumpFile"
+done

--- a/scripts/resetdb.sh
+++ b/scripts/resetdb.sh
@@ -13,7 +13,7 @@ DB_RESTORE_DIR=$1
 # Reset DB
 scripts/exec.sh "db.dropDatabase()"
 
-scripts/join_splitted_files.sh $DB_RESTORE_DIR
+scripts/join_splitted_files.sh "$DB_RESTORE_DIR"
 
 # Extract BSON's
 for assetDirectory in "$DB_RESTORE_DIR"/*/

--- a/scripts/resetdb.sh
+++ b/scripts/resetdb.sh
@@ -13,14 +13,19 @@ DB_RESTORE_DIR=$1
 # Reset DB
 scripts/exec.sh "db.dropDatabase()"
 
+scripts/join_splitted_files.sh $DB_RESTORE_DIR
+
 # Extract BSON's
-for entry in "$DB_RESTORE_DIR"/*.tar.gz
+for assetDirectory in "$DB_RESTORE_DIR"/*/
 do
-    tar -xvf "$entry" -C "$DB_RESTORE_DIR"
+    for compressedFile in "$assetDirectory"*.tar.gz
+    do
+        tar -xvf "$compressedFile" -C "$assetDirectory"
+    done
 done
 
 # Restore collections
-for entry in "$DB_RESTORE_DIR"/*.bson
+for entry in "$DB_RESTORE_DIR"/*/*.bson
 do
     # Restore dump
     scripts/restore.sh "$entry"


### PR DESCRIPTION
Este PR visa endereçar a limitação de repositório template que possui arquivos com mais de 10MB de tamanho.

Para testar esta solução:

1. Foi criado um repositório [template](https://github.com/betrybe/sd-000-project-mongodb-dataflights) de teste, que essencialmente é o projeto original [Mongo dataflights](https://github.com/betrybe/sd-0x-project-mongodb-dataflights) com a inclusão do arquivo de dump [dividido em 2 partes](https://github.com/betrybe/sd-000-project-mongodb-dataflights/tree/master/assets/voos/splitted-files).
2. Foi disponibilizado em `staging` um [projeto a partir desse template](https://github.com/betrybe/sd-000-project-mongodb-dataflights-staging) via uso da action `Release project` do `Forest Admin`.
3. Foi [testado](https://github.com/betrybe/sd-000-project-mongodb-dataflights-staging/pull/1) o fluxo completo de avaliação, usando este PR para fazer as avaliações. Pode-se ver no pull request em questão duas avaliações, onde  i) 0% dos requisitos passaram e ii) 100% dos requisitos passaram. Foi testado localmente também a execução local dessas avaliações.