### PR TITLE
Prepara avaliador para v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: MongoDB Query Evaluator Step
-        uses: betrybe/mongodb-query-evaluator-action@v2
+        uses: betrybe/mongodb-query-evaluator-action@v3
         id: mongodb-query-evaluator
         env:
           DBNAME: 'aggregations'
@@ -109,10 +109,6 @@ challenges/
 #### `result`
 
 Evaluation result JSON in base64 format.
-
-#### `pr-number`
-
-Pull Request number that trigger build.
 
 ## Trybe requirements and expected results
 

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,6 @@ inputs:
 outputs:
   result:
     description: 'Evaluation JSON results in base64 format.'
-  pr-number:
-    description: 'Pull Request number that trigger build.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,13 +3,6 @@
 DB_RESTORE_DIR=$1
 CHALLENGES_DIR=$2
 
-git clone https://github.com/$GITHUB_REPOSITORY.git --single-branch /github/master-repo/
-
-if [ $? != 0 ]; then
-  printf "Execution error $?"
-  exit 1
-fi
-
 cd /
 scripts/generate_result.sh "/github/workspace/$CHALLENGES_DIR" "/github/master-repo/.trybe" "/github/workspace/$DB_RESTORE_DIR"
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4,7 +4,7 @@ DB_RESTORE_DIR=$1
 CHALLENGES_DIR=$2
 
 cd /
-scripts/generate_result.sh "/github/workspace/$CHALLENGES_DIR" "/github/master-repo/.trybe" "/github/workspace/$DB_RESTORE_DIR"
+scripts/generate_result.sh "/github/workspace/$CHALLENGES_DIR" "/github/workspace/.trybe" "/github/workspace/$DB_RESTORE_DIR"
 
 if [ $? != 0 ]; then
   printf "Execution error $?"


### PR DESCRIPTION
- Retira output variable `pr-number` pois não é mais utilizada (utilizamos `github.event.number`)
- Retira comando que faz clone da versão que está na _branch_ principal. Essa responsabilidade será de uma outra GitHub Action