### PR TITLE
imp: renomeia inputs e adc PR author username

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,25 @@ jobs:
 
 ### Inputs
 
-#### `repository-import-folder`
+This action accepts the following configuration parameters via `with:`
 
-GitHub repository on master directory that contains the `tar.gz` (compression of the `.bson` file) with the dataset collections to be restored.
+- `db_restore_dir`
+
+  **Required**
+
+  GitHub repository directory that contains the dataset collections to be restored.
+
+  - `challenges_dir`
+
+  **Required**
+
+  GitHub repository directory that contains the student MQL scripts.
+
+- `pr_author_username`
+
+  **Required**
+
+  Pull Request author username.
 
 ##### Observations
 

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,16 @@
 name: 'MongoDB query evaluator'
 description: 'MongoDB query evaluator action for Tryber projects'
 inputs:
-  repository-import-folder:
-    description: 'GitHub repository folder that contains the BSONs.'
+  db_restore_dir:
+    description: 'GitHub repository directory that contains the dataset collections to be restored.'
     default: 'assets'
     required: true
-  repository-challenges-folder:
-    description: 'GitHub repository folder that contains the MQL scripts.'
+  challenges_dir:
+    description: 'GitHub repository directory that contains the student MQL scripts.'
     default: 'challenges'
+    required: true
+  pr_author_username:
+    description: 'Pull Request author username.'
     required: true
 outputs:
   result:
@@ -15,6 +18,3 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.repository-import-folder }}
-    - ${{ inputs.repository-challenges-folder }}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,10 +1,7 @@
 #!/bin/sh -l
 
-DB_RESTORE_DIR=$1
-CHALLENGES_DIR=$2
-
 cd /
-scripts/generate_result.sh "/github/workspace/$CHALLENGES_DIR" "/github/workspace/.trybe" "/github/workspace/$DB_RESTORE_DIR"
+scripts/generate_result.sh "/github/workspace/$INPUT_CHALLENGES_DIR" "/github/workspace/.trybe" "/github/workspace/$INPUT_DB_RESTORE_DIR"
 
 if [ $? != 0 ]; then
   printf "Execution error $?"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,4 +9,3 @@ if [ $? != 0 ]; then
 fi
 
 echo ::set-output name=result::`cat /tmp/trybe-results/evaluation_result.json | base64 -w 0`
-echo ::set-output name=pr-number::$(echo "$GITHUB_REF" | awk -F / '{print $3}')

--- a/scripts/generate_result.sh
+++ b/scripts/generate_result.sh
@@ -23,9 +23,9 @@ mkdir "$RESULTS_DIR"
 # Create result collection with project data
 DBNAME=trybe scripts/exec.sh "db.dropDatabase()"
 DBNAME=trybe scripts/exec.sh 'db.createCollection("evaluation")'
-doc='{"github_username": "'"$GITHUB_ACTOR"'","github_repository_name": "'"$GITHUB_REPOSITORY"'","evaluations": []}'
+doc='{"github_username": "'"$INPUT_PR_AUTHOR_USERNAME"'","github_repository_name": "'"$GITHUB_REPOSITORY"'","evaluations": []}'
 DBNAME=trybe scripts/exec.sh "db.evaluation.insertOne($doc)"
-docIdentifier='{"github_username": "'"$GITHUB_ACTOR"'"}'
+docIdentifier='{"github_username": "'"$INPUT_PR_AUTHOR_USERNAME"'"}'
 
 # Add challenge result to evaluation collection
 function updateEvaluation {


### PR DESCRIPTION
Renomeia inputs para usar como envvars

Devido as alterações na [LEARN-869](https://trybe.atlassian.net/browse/LEARN-869?atlOrigin=eyJpIjoiNDZlNGJlYTljYzM2NDRhZmI0OGU3Njk1MGYwZGJmN2UiLCJwIjoiaiJ9), no qual o _workflow_ é executado via `dispatch`, a _envvar_ `GITHUB_ACTOR` é o Github App de Selfhosted então é necessário passar o **username** via **input**.