### PR TITLE
Ordena resultados por chave para comparar

### DIFF
--- a/scripts/exec.sh
+++ b/scripts/exec.sh
@@ -19,5 +19,5 @@ if [[ -z "$mongoContainerID" ]]; then
 fi
 
 # Exec MQL
-cmd="mongo $DBNAME --quiet --eval 'DBQuery.shellBatchSize = 100000; DBQuery.prototype._prettyShell = true; $mql'"
+cmd="mongo $DBNAME --quiet --eval 'DBQuery.shellBatchSize = 100000; DBQuery.prototype._prettyShell = true; JSON.stringify($mql); $mql'"
 docker exec "$mongoContainerID" bash -c "$cmd"

--- a/scripts/exec.sh
+++ b/scripts/exec.sh
@@ -19,5 +19,5 @@ if [[ -z "$mongoContainerID" ]]; then
 fi
 
 # Exec MQL
-cmd="mongo $DBNAME --quiet --eval 'DBQuery.shellBatchSize = 100000; DBQuery.prototype._prettyShell = true; JSON.stringify($mql); $mql'"
+cmd="mongo $DBNAME --quiet --eval 'DBQuery.shellBatchSize = 100000; DBQuery.prototype._prettyShell = true; JSON.stringify($mql);'"
 docker exec "$mongoContainerID" bash -c "$cmd"

--- a/scripts/generate_result.sh
+++ b/scripts/generate_result.sh
@@ -31,7 +31,7 @@ DBNAME=trybe scripts/exec.sh "db.evaluation.insertOne($doc)"
 docIdentifier='{"github_username": "'"$INPUT_PR_AUTHOR_USERNAME"'"}'
 
 # Add challenge result to evaluation collection
-function updateEvaluation {
+updateEvaluation() {
   chName=$1
   chDesc=$2
   grade=$3
@@ -56,10 +56,10 @@ do
     continue
   fi
   # Exec query into mongo container and sort result
-  mql=$(cat "$mqlFile")
+  mql=$(cat "$mqlFile" | sed -r "s/;+$//")
   scripts/exec.sh "$mql" | jq -S &> "$resultPath"
   # Sort expected result
-  cat $TRYBE_DIR/expected-results/$chName | jq -S > "/tmp/expected_sorted"
+  cat "$TRYBE_DIR/expected-results/$chName" | jq -S > "/tmp/expected_sorted"
   # Check result with the expected and build doc to add into result collection
   diff=$(diff "$resultPath" "/tmp/expected_sorted" --ignore-all-space)
   if [[ ! -z "$diff" ]]; then

--- a/scripts/generate_result.sh
+++ b/scripts/generate_result.sh
@@ -57,7 +57,7 @@ do
   fi
   # Exec query into mongo container and sort result
   mql=$(cat "$mqlFile" | sed -r "s/;+$//")
-  scripts/exec.sh "$mql" | jq -S &> "$resultPath"
+  scripts/exec.sh "$mql" | jq ._batch[] -S &> "$resultPath"
   # Sort expected result
   cat "$TRYBE_DIR/expected-results/$chName" | jq -S > "/tmp/expected_sorted"
   # Check result with the expected and build doc to add into result collection

--- a/scripts/generate_result.sh
+++ b/scripts/generate_result.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -l
 
+CORRECT_GRADE=3
+INCORRECT_GRADE=1
+
 if [[ -z "$1" ]]; then
     printf "You must pass the challenges dir as the first argument\n"
     exit 1
@@ -49,20 +52,22 @@ do
   # Check if challenge MQL file exists
   mqlFile="$CHALLENGES_DIR/$chName".js
   if [ ! -f $mqlFile ]; then
-    updateEvaluation "$chName" "$chDesc" 1
+    updateEvaluation "$chName" "$chDesc" $INCORRECT_GRADE
     continue
   fi
-  # Exec query into mongo container
+  # Exec query into mongo container and sort result
   mql=$(cat "$mqlFile")
-  scripts/exec.sh "$mql" &> "$resultPath"
+  scripts/exec.sh "$mql" | jq -S &> "$resultPath"
+  # Sort expected result
+  cat $TRYBE_DIR/expected-results/$chName | jq -S > "/tmp/expected_sorted"
   # Check result with the expected and build doc to add into result collection
-  diff=$(diff "$resultPath" "$TRYBE_DIR/expected-results/$chName" --ignore-all-space)
+  diff=$(diff "$resultPath" "/tmp/expected_sorted" --ignore-all-space)
   if [[ ! -z "$diff" ]]; then
-    updateEvaluation "$chName" "$chDesc" 1
+    updateEvaluation "$chName" "$chDesc" $INCORRECT_GRADE
     continue
   fi
 
-  updateEvaluation "$chName" "$chDesc" 3
+  updateEvaluation "$chName" "$chDesc" $CORRECT_GRADE
 done
 
 DBNAME=trybe scripts/exec.sh "db.evaluation.findOne($docIdentifier, {_id: 0})" > "$RESULTS_DIR/evaluation_result.json"


### PR DESCRIPTION
PR para tentar solucionar o problema apontado nesta [thread](https://betrybe.slack.com/archives/C0160E5M3A6/p1623933180020400). 

Ordena o resultado da MQL assim como o arquivo de resultado esperado para que estejam ordenados pelas keys, e assim, evitar dar errado quando o resultado está correto, mas com ordenação diferente, já que a comparação é absoluta.